### PR TITLE
Fix typos and outdated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# libraries/report-size-trends action
+# arduino/report-size-trends action
 
-This action records the memory usage of the sketch specified to the [`arduino/actions/libraries/compile-examples` action](../compile-examples)'s [`size-report-sketch` input](../compile-examples/README.md#size-report-sketch) to a Google Sheets spreadsheet.
+This action records the memory usage of the sketch specified to the [`arduino/compile-examples` action](https://github.com/arduino/compile-sketches)'s [`size-report-sketch` input](https://github.com/arduino/compile-sketches#size-report-sketch) to a Google Sheets spreadsheet.
 
 ## Inputs
 
 ### `sketches-report-path`
 
-Path that contains the JSON formatted sketch data report, as specified to the `arduino/actions/libraries/compile-examples` action's [sketches-report-path input](../compile-examples/README.md#sketches-report-path). Default `"size-deltas-reports"`.
+Path that contains the JSON formatted sketch data report, as specified to the `arduino/compile-examples` action's [sketches-report-path input](https://github.com/arduino/compile-sketches#sketches-report-path). Default `"size-deltas-reports"`.
 
 ### `google-key-file`
 
@@ -66,9 +66,9 @@ The sheet name in the Google Sheets spreadsheet used for the memory usage trends
 ## Example usage
 
 ```yaml
-- uses: arduino/actions/libraries/compile-examples@master
   with:
     size-report-sketch: Foobar
+- uses: arduino/compile-sketches@master
 # Publish size trends report on each push to the master branch
 - if: github.event_name == 'push' && github.ref == 'refs/heads/master'
   uses: arduino/actions/libraries/report-size-trends@master

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Path that contains the JSON formatted sketch data report, as specified to the `a
 1. Click the "Settings" tab.
 1. From the menu on the left side of the window, click "Secrets".
 1. Click the "Add a new secret" link.
-1. In the "Name" field, enter the variable name you want to use for your secret. This will be used for the `size-trends-report-key-file` argument of the `compile-examples` action in your workflow configuration file. For example, if you named the secret `GOOGLE_KEY_FILE`, you would reference it in your workflow configuration as `${{ secrets.GOOGLE_KEY_FILE }}`.
+1. In the "Name" field, enter the variable name you want to use for your secret. This secret is what you will use in the `arduino/report-size-trends` action's `google-key-file` input in your GitHub Actions workflow configuration file. For example, if you named the secret `GOOGLE_KEY_FILE`, the input would look like `google-key-file: ${{ secrets.GOOGLE_KEY_FILE }}`.
 1. In the "Value" field, paste the contents of the key file.
 1. Click the "Add secret" button.
 1. Open the downloaded key file again.
@@ -66,8 +66,6 @@ The sheet name in the Google Sheets spreadsheet used for the memory usage trends
 ## Example usage
 
 ```yaml
-  with:
-    size-report-sketch: Foobar
 - uses: arduino/compile-sketches@master
 # Publish size trends report on each push to the master branch
 - if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'Arduino Libraries - Report Size Trends'
+name: 'Report Arduino Sketch Size Trends'
 description: 'Records sketch memory usage to a Google Sheets spreadsheet'
 inputs:
   sketches-report-path:
-    description: 'Path the arduino/actions/libraries/compile-examples action saved the sketch data report to'
+    description: 'Path the arduino/compile-examples action saved the sketch data report to'
     required: false
     default: 'size-deltas-reports'
   google-key-file:


### PR DESCRIPTION
The move to new repository resulted in some parts of the documentation needing updates.