### PR TITLE
Use appropriate default value for sketches-report-path input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This action records the memory usage of the [Arduino](https://www.arduino.cc/) s
 
 Path that contains the sketches report, as specified to the `arduino/compile-examples` action's [sketches-report-path input](https://github.com/arduino/compile-sketches#sketches-report-path).
 
-**Default**: `"size-deltas-reports"`
+**Default**: `"sketches-reports"`
 
 ### `google-key-file`
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   sketches-report-path:
     description: 'Path the arduino/compile-examples action saved the sketch data report to'
     required: false
-    default: 'size-deltas-reports'
+    default: 'sketches-reports'
   google-key-file:
     description: 'Google key file used to update the size trends report Google Sheets spreadsheet.'
     required: true


### PR DESCRIPTION
In the time since it was first conceived, the use of the report file created by the `arduino/compile-sketches` action has been expanded from only being a way to pass memory usage change data to the `arduino/report-size-deltas` action to a general purpose report of data generated from the sketch compilations, including:

- Non-deltas size data consumed by this action
- Compilation status for each sketch/board combination
- Compiler warning count

It's possible additional information will be added to the report over time.

For this reason, the previous default `size-deltas-reports` was no longer appropriate and might be the source of confusion. This issue was especially prominent for this action, since it doesn't require or make any use of the the size deltas data in the report and is perfectly happy even if the deltas feature of `arduino/compile-sketches` is disabled!

Because the default value of `arduino/compile-sketches` and this action's inputs are being changed at the same time, it's very unlikely for this to cause any breakage.