### PR TITLE
Use Python 3.8.6 in CI and Docker container

### DIFF
--- a/.github/workflows/libraries_report-size-trends.yml
+++ b/.github/workflows/libraries_report-size-trends.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8.5'
+          python-version: '3.8.6'
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.5
+FROM python:3.8.6
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY reportsizetrends /reportsizetrends


### PR DESCRIPTION
The 	`actions/setup-python` action used to install Python for use in the CI workflows no longer offers Python 3.8.5,
which will cause the CI to fail.

The action should use the same version of Python it's tested with, so I have also updated the action's Docker image to
`python:3.8.6`.